### PR TITLE
Replaced idem-metadata with edugain2idem-metadata

### DIFF
--- a/garr/shib2idp/files/statistics/config.php
+++ b/garr/shib2idp/files/statistics/config.php
@@ -35,7 +35,7 @@ $backupIDPConfigFile = 'IDProvider.conf.php';
 
 // Use $metadataFile as source federation's metadata.
 //$metadataFile = '/etc/shibboleth/metadata.switchaai.xml';
-$metadataFile = '/root/loganalysis/idem-metadata-sha256.xml';
+$metadataFile = '/root/loganalysis/edugain2idem-metadata-sha256.xml';
 
 // File to store the parsed IdP list
 // Will be updated automatically if the metadataFile modification time

--- a/garr/shib2idp/manifests/classes/management/statistics.pp
+++ b/garr/shib2idp/manifests/classes/management/statistics.pp
@@ -106,10 +106,10 @@ class shib2idp::management::statistics (
       require => File[$stats_installdir],
     }
   } else {
-    file { 'idem-metadata-sha256.xml':
-      path    => "${stats_installdir}/idem-metadata-sha256.xml",
+    file { 'edugain2idem-metadata-sha256.xml':
+      path    => "${stats_installdir}/edugain2idem-metadata-sha256.xml",
       ensure  => link,
-      target  => "/opt/shibboleth-idp/metadata/idem-metadata-sha256.xml",
+      target  => "/opt/shibboleth-idp/metadata/edugain2idem-metadata-sha256.xml",
       require => File[$stats_installdir],
     }
   }

--- a/garr/shib2idp/manifests/definitions/instance.pp
+++ b/garr/shib2idp/manifests/definitions/instance.pp
@@ -188,7 +188,7 @@ define shib2idp::instance (
     }
   
     file { 'metadata-federation.xml':
-      path  => '/opt/shibboleth-idp/metadata/idem-metadata-sha256.xml',
+      path  => '/opt/shibboleth-idp/metadata/edugain2idem-metadata-sha256.xml',
       ensure  => absent,
       owner   => $curtomcat,
       group   => $curtomcat,
@@ -198,17 +198,17 @@ define shib2idp::instance (
   else{
     File['metadata-federation.xml']~>Exec['shib2-tomcat-restart']
 
-    download_file{ '/opt/shibboleth-idp/metadata/idem-metadata-sha256.xml':
-      url   => "http://www.garr.it/idem-metadata/idem-metadata-sha256.xml",
+    download_file{ '/opt/shibboleth-idp/metadata/edugain2idem-metadata-sha256.xml':
+      url   => "http://www.garr.it/idem-metadata/edugain2idem-metadata-sha256.xml",
     }
 
     file { 'metadata-federation.xml':
-      path  => '/opt/shibboleth-idp/metadata/idem-metadata-sha256.xml',
+      path  => '/opt/shibboleth-idp/metadata/edugain2idem-metadata-sha256.xml',
       ensure  => present,
       owner   => $curtomcat,
       group   => $curtomcat,
       mode    => '0644',
-      require => Download_file['/opt/shibboleth-idp/metadata/idem-metadata-sha256.xml'],
+      require => Download_file['/opt/shibboleth-idp/metadata/edugain2idem-metadata-sha256.xml'],
     }
 
     file { 'metadata-test-federation.xml':

--- a/garr/shib2idp/templates/relying-party.xml.erb
+++ b/garr/shib2idp/templates/relying-party.xml.erb
@@ -109,8 +109,8 @@
 <% else -%>
          <metadata:MetadataProvider id="URLMD-IDEM-Federation"
                                     xsi:type="metadata:FileBackedHTTPMetadataProvider"
-                                    metadataURL="http://www.garr.it/idem-metadata/idem-metadata-sha256.xml"
-                                    backingFile="/opt/shibboleth-idp/metadata/idem-metadata-sha256.xml">
+                                    metadataURL="http://www.garr.it/idem-metadata/edugain2idem-metadata-sha256.xml"
+                                    backingFile="/opt/shibboleth-idp/metadata/edugain2idem-metadata-sha256.xml">
 <% end -%>
             <metadata:MetadataFilter xsi:type="metadata:ChainingFilter">
                     <metadata:MetadataFilter xsi:type="metadata:SignatureValidation" trustEngineRef="shibboleth.MetadataTrustEngine" requireSignedMetadata="true" />


### PR DESCRIPTION
Hi Andrea,

here you can find the modifies that replace "idem-metadata-sha256" with "edugain2idem-metadata-sha256" as requested for IDEM.

Best Regards,
Marco
